### PR TITLE
Fix repeatedly add and remove same branch does not trigger build 

### DIFF
--- a/assets/check
+++ b/assets/check
@@ -45,12 +45,12 @@ else
       removed: $removed,
       added: $added,
       branches: $branches,
-      date: $date
+      check_date: $check_date
     }
   ]' \
     --arg removed "$removed" \
     --arg added "$added" \
     --arg branches "$current_branches" \
-    --arg date "$(date)" \
+    --arg check_date "$(date '+%Y-%m-%d %H:%M:%S %z')" \
     >&3
 fi

--- a/assets/check
+++ b/assets/check
@@ -34,7 +34,8 @@ set_sub() {
 echo "previous: $previous_branches"
 echo "current:  $current_branches"
 
-if [ "$current_branches" = "$previous_branches" ]; then
+# $current_branches should not be empty
+if [ -z "$current_branches" ] || [ "$current_branches" = "$previous_branches" ]; then
   echo '[]' >&3
 else
   removed="$(set_sub "$previous_branches" "$current_branches")"

--- a/assets/check
+++ b/assets/check
@@ -44,11 +44,13 @@ else
     {
       removed: $removed,
       added: $added,
-      branches: $branches
+      branches: $branches,
+      date: $date
     }
   ]' \
     --arg removed "$removed" \
     --arg added "$added" \
     --arg branches "$current_branches" \
+    --arg date "$(date)" \
     >&3
 fi

--- a/assets/in
+++ b/assets/in
@@ -22,6 +22,11 @@ cd $destination
 jq -r '.version.branches // ""' < $payload > branches
 jq -r '.version.added // ""' < $payload > added
 jq -r '.version.removed // ""' < $payload > removed
-jq -r '.version.date // ""' < $payload > date
+jq -r '.version.check_date // ""' < $payload > check_date
 
-jq '{version}' < $payload >&3
+jq -n "{
+  version: $(jq -r '.version' < $payload),
+  metadata: [
+    { name: \"check_date\", value: $( jq -R . check_date)}
+  ]
+}" >&3

--- a/assets/in
+++ b/assets/in
@@ -22,5 +22,6 @@ cd $destination
 jq -r '.version.branches // ""' < $payload > branches
 jq -r '.version.added // ""' < $payload > added
 jq -r '.version.removed // ""' < $payload > removed
+jq -r '.version.date // ""' < $payload > date
 
 jq '{version}' < $payload >&3


### PR DESCRIPTION
If repeatedly add and remove same branch, you will see only first add/remove action can trigger build.
Because concourse does not auto trigger builds for same input.
![Peek 2020-10-09 11-22](https://user-images.githubusercontent.com/10131648/95541016-cda25380-0a24-11eb-8e6c-68a62878ae17.gif)

To fix this issue, it need add a unique value to version.

